### PR TITLE
Allow for editable pip installs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,5 +37,5 @@ vcs = "git"
 style = "semver"
 
 [build-system]
-requires = ["poetry>=1.0"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core @ git+https://github.com/python-poetry/poetry-core.git@master"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
This change enables somebody to do an ['editable'](https://pip.pypa.io/en/stable/cli/pip_install/#editable-installs) pip install for development, so that changes to code automatically are available in the python interpreter. For example:

```
git clone https://github.com/fastice/gimpfunc.git
cd gimpfunc
pip install -e .
```

If you are working in ipython or a jupyter notebook you might need the following in a cell:
```
%load_ext autoreload
%autoreload 2
```
(https://stackoverflow.com/questions/1907993/autoreload-of-modules-in-ipython)
