### PR TITLE
add setuptools to build requirements for mybinder.org

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,5 +37,5 @@ vcs = "git"
 style = "semver"
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
+requires = ["setuptools","poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
To enable mybinder.org and avoid the following traceback when installing via pip:

```pytb
Pip subprocess error:
 Running command git clone --filter=blob:none -q https://github.com/fastice/gimpfunc.git /tmp/pip-req-build-i2ckd_ux
ERROR: Exception:
Traceback (most recent call last):
 File "/srv/conda/envs/notebook/lib/python3.8/site-packages/pip/_internal/cli/base_command.py", line 164, in exc_logging_wrapper
   status = run_func(*args)
 File "/srv/conda/envs/notebook/lib/python3.8/site-packages/pip/_internal/cli/req_command.py", line 205, in wrapper
   return func(self, options, args)
 File "/srv/conda/envs/notebook/lib/python3.8/site-packages/pip/_internal/commands/install.py", line 338, in run
   requirement_set = resolver.resolve(
 File "/srv/conda/envs/notebook/lib/python3.8/site-packages/pip/_internal/resolution/resolvelib/resolver.py", line 73, in resolve
   collected = self.factory.collect_root_requirements(root_reqs)
 File "/srv/conda/envs/notebook/lib/python3.8/site-packages/pip/_internal/resolution/resolvelib/factory.py", line 468, in collect_root_requirements
   req = self._make_requirement_from_install_req(
 File "/srv/conda/envs/notebook/lib/python3.8/site-packages/pip/_internal/resolution/resolvelib/factory.py", line 430, in _make_requirement_from_install_req
   cand = self._make_candidate_from_link(
 File "/srv/conda/envs/notebook/lib/python3.8/site-packages/pip/_internal/resolution/resolvelib/factory.py", line 201, in _make_candidate_from_link
   self._link_candidate_cache[link] = LinkCandidate(
 File "/srv/conda/envs/notebook/lib/python3.8/site-packages/pip/_internal/resolution/resolvelib/candidates.py", line 281, in __init__
   super().__init__(
 File "/srv/conda/envs/notebook/lib/python3.8/site-packages/pip/_internal/resolution/resolvelib/candidates.py", line 156, in __init__
   self.dist = self._prepare()
 File "/srv/conda/envs/notebook/lib/python3.8/site-packages/pip/_internal/resolution/resolvelib/candidates.py", line 225, in _prepare
   dist = self._prepare_distribution()
 File "/srv/conda/envs/notebook/lib/python3.8/site-packages/pip/_internal/resolution/resolvelib/candidates.py", line 292, in _prepare_distribution
   return preparer.prepare_linked_requirement(self._ireq, parallel_builds=True)
 File "/srv/conda/envs/notebook/lib/python3.8/site-packages/pip/_internal/operations/prepare.py", line 482, in prepare_linked_requirement
   return self._prepare_linked_requirement(req, parallel_builds)
 File "/srv/conda/envs/notebook/lib/python3.8/site-packages/pip/_internal/operations/prepare.py", line 546, in _prepare_linked_requirement
   dist = _get_prepared_distribution(
 File "/srv/conda/envs/notebook/lib/python3.8/site-packages/pip/_internal/operations/prepare.py", line 58, in _get_prepared_distribution
   abstract_dist.prepare_distribution_metadata(finder, build_isolation)
 File "/srv/conda/envs/notebook/lib/python3.8/site-packages/pip/_internal/distributions/sdist.py", line 47, in prepare_distribution_metadata
   self._install_build_reqs(finder)
 File "/srv/conda/envs/notebook/lib/python3.8/site-packages/pip/_internal/distributions/sdist.py", line 106, in _install_build_reqs
   build_reqs = self._get_build_requires_wheel()
 File "/srv/conda/envs/notebook/lib/python3.8/site-packages/pip/_internal/distributions/sdist.py", line 83, in _get_build_requires_wheel
   return backend.get_requires_for_build_wheel()
 File "/srv/conda/envs/notebook/lib/python3.8/site-packages/pip/_vendor/pep517/wrappers.py", line 172, in get_requires_for_build_wheel
   return self._call_hook('get_requires_for_build_wheel', {
 File "/srv/conda/envs/notebook/lib/python3.8/site-packages/pip/_vendor/pep517/wrappers.py", line 332, in _call_hook
   raise BackendUnavailable(data.get('traceback', ''))
pip._vendor.pep517.wrappers.BackendUnavailable: Traceback (most recent call last):
 File "/srv/conda/envs/notebook/lib/python3.8/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 89, in _build_backend
   obj = import_module(mod_path)
 File "/srv/conda/envs/notebook/lib/python3.8/importlib/__init__.py", line 127, in import_module
   return _bootstrap._gcd_import(name[level:], package, level)
 File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
 File "<frozen importlib._bootstrap>", line 991, in _find_and_load
 File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
 File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
 File "<frozen importlib._bootstrap_external>", line 843, in exec_module
 File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
 File "/tmp/pip-build-env-dl6i_xy6/overlay/lib/python3.8/site-packages/poetry/masonry/api.py", line 1, in <module>
   from poetry.core.masonry.api import build_sdist
 File "/tmp/pip-build-env-dl6i_xy6/overlay/lib/python3.8/site-packages/poetry/core/masonry/__init__.py", line 10, in <module>
   from .builder import Builder
 File "/tmp/pip-build-env-dl6i_xy6/overlay/lib/python3.8/site-packages/poetry/core/masonry/builder.py", line 7, in <module>
   from .builders.sdist import SdistBuilder
 File "/tmp/pip-build-env-dl6i_xy6/overlay/lib/python3.8/site-packages/poetry/core/masonry/builders/__init__.py", line 2, in <module>
   from .wheel import WheelBuilder
 File "/tmp/pip-build-env-dl6i_xy6/overlay/lib/python3.8/site-packages/poetry/core/masonry/builders/wheel.py", line 23, in <module>
   from packaging.tags import sys_tags
 File "/tmp/pip-build-env-dl6i_xy6/overlay/lib/python3.8/site-packages/poetry/core/_vendor/packaging/tags.py", line 7, in <module>
   import distutils.util
 File "/srv/conda/envs/notebook/lib/python3.8/site-packages/_distutils_hack/__init__.py", line 92, in create_module
   return importlib.import_module('setuptools._distutils')
 File "/srv/conda/envs/notebook/lib/python3.8/importlib/__init__.py", line 127, in import_module
   return _bootstrap._gcd_import(name[level:], package, level)
ModuleNotFoundError: No module named 'setuptools'
```